### PR TITLE
set learn_rate for lbfgs to 1 and update examples

### DIFF
--- a/R/lantern_linear_reg-fit.R
+++ b/R/lantern_linear_reg-fit.R
@@ -29,9 +29,10 @@
 #' @param penalty The amount of weight decay (i.e., L2 regularization).
 #' @param optimizer The method used in the optimization procedure. Possible choices
 #'   are 'LBFGS' and 'SGD'. Default is 'LBFGS'.
-#' @param learn_rate A positive number (usually less than 0.1).
+#' @param learn_rate A positive number. Default is 1 for LBFGS; smaller values
+#' # are normally chosen for other optimizers.
 #' @param momentum A positive number on `[0, 1]` for the momentum parameter in
-#'  gradient decent.
+#'  gradient descent.
 #' @param validation The proportion of the data randomly assigned to a
 #'  validation set.
 #' @param batch_size An integer for the number of training set points in each
@@ -87,7 +88,7 @@
 #'  set.seed(1)
 #'  lantern_linear_reg(x = as.matrix(ames_train[, c("Longitude", "Latitude")]),
 #'                     y = ames_train$Sale_Price,
-#'                     penalty = 0.10, epochs = 20, batch_size = 32)
+#'                     penalty = 0.10, epochs = 1, batch_size = 64)
 #'
 #'  # Using recipe
 #'  library(recipes)
@@ -109,7 +110,7 @@
 #'
 #'  set.seed(2)
 #'  fit <- lantern_linear_reg(ames_rec, data = ames_train,
-#'                            epochs = 20, batch_size = 32)
+#'                            epochs = 5, batch_size = 32)
 #'  fit
 #'
 #'  autoplot(fit)
@@ -154,7 +155,7 @@ lantern_linear_reg.data.frame <-
            penalty = 0.001,
            validation = 0,
            optimizer = "LBFGS",
-           learn_rate = 0.01,
+           learn_rate = 1,
            momentum = 0.0,
            batch_size = NULL,
            conv_crit = -Inf,
@@ -187,7 +188,7 @@ lantern_linear_reg.matrix <- function(x,
                                penalty = 0.001,
                                validation = 0,
                                optimizer = "LBFGS",
-                               learn_rate = 0.01,
+                               learn_rate = 1,
                                momentum = 0.0,
                                batch_size = NULL,
                                conv_crit = -Inf,
@@ -221,7 +222,7 @@ lantern_linear_reg.formula <-
            penalty = 0.001,
            validation = 0,
            optimizer = "LBFGS",
-           learn_rate = 0.01,
+           learn_rate = 1,
            momentum = 0.0,
            batch_size = NULL,
            conv_crit = -Inf,
@@ -255,7 +256,7 @@ lantern_linear_reg.recipe <-
            penalty = 0.001,
            validation = 0,
            optimizer = "LBFGS",
-           learn_rate = 0.01,
+           learn_rate = 1,
            momentum = 0.0,
            batch_size = NULL,
            conv_crit = -Inf,
@@ -389,7 +390,7 @@ lantern_linear_reg_reg_fit_imp <-
            penalty = 0.001,
            validation = 0,
            optimizer = "LBFGS",
-           learn_rate = 0.01,
+           learn_rate = 1,
            momentum = 0.0,
            conv_crit = -Inf,
            verbose = FALSE,

--- a/R/lantern_linear_reg-fit.R
+++ b/R/lantern_linear_reg-fit.R
@@ -30,7 +30,7 @@
 #' @param optimizer The method used in the optimization procedure. Possible choices
 #'   are 'LBFGS' and 'SGD'. Default is 'LBFGS'.
 #' @param learn_rate A positive number. Default is 1 for LBFGS; smaller values
-#' # are normally chosen for other optimizers.
+#' are normally chosen for other optimizers.
 #' @param momentum A positive number on `[0, 1]` for the momentum parameter in
 #'  gradient descent.
 #' @param validation The proportion of the data randomly assigned to a
@@ -155,7 +155,7 @@ lantern_linear_reg.data.frame <-
            penalty = 0.001,
            validation = 0,
            optimizer = "LBFGS",
-           learn_rate = 1,
+           learn_rate = 1.0,
            momentum = 0.0,
            batch_size = NULL,
            conv_crit = -Inf,

--- a/R/lantern_logistic_reg-fit.R
+++ b/R/lantern_logistic_reg-fit.R
@@ -154,7 +154,7 @@ lantern_logistic_reg.data.frame <-
           penalty = 0,
           validation = 0.1,
           optimizer = "LBFGS",
-          learn_rate = 1,
+          learn_rate = 1.0,
           momentum = 0.0,
           batch_size = NULL,
           conv_crit = -Inf,

--- a/R/lantern_logistic_reg-fit.R
+++ b/R/lantern_logistic_reg-fit.R
@@ -27,7 +27,6 @@
 #'
 #' @param epochs An integer for the number of epochs of training.
 #' @param penalty The amount of weight decay (i.e., L2 regularization).
-#' @param learn_rate A positive number (usually less than 0.1).
 #' @param momentum A positive number on `[0, 1]` for the momentum parameter in
 #'  gradient decent.
 #' @param validation The proportion of the data randomly assigned to a
@@ -84,7 +83,7 @@
 #'  set.seed(1)
 #'  lantern_logistic_reg(x = as.matrix(cells_train[, c("fiber_width_ch_1", "width_ch_1")]),
 #'                       y = cells_train$class,
-#'                       penalty = 0.10, epochs = 20L)
+#'                       penalty = 0.10, epochs = 3)
 #'
 #'  # Using recipe
 #'  library(recipes)
@@ -98,7 +97,7 @@
 #'
 #'  set.seed(2)
 #'  fit <- lantern_logistic_reg(cells_rec, data = cells_train,
-#'                              penalty = .01, epochs = 20L)
+#'                              penalty = .01, epochs = 5)
 #'  fit
 #'
 #'  autoplot(fit)
@@ -125,7 +124,7 @@
 #'   step_normalize(all_predictors())
 #'
 #'  set.seed(3)
-#'  fit <- lantern_logistic_reg(rec, data = penguins_train, epochs = 20L)
+#'  fit <- lantern_logistic_reg(rec, data = penguins_train, epochs = 5)
 #'  fit
 #'
 #'  predict(fit, penguins_test) %>%
@@ -155,7 +154,7 @@ lantern_logistic_reg.data.frame <-
           penalty = 0,
           validation = 0.1,
           optimizer = "LBFGS",
-          learn_rate = 0.01,
+          learn_rate = 1,
           momentum = 0.0,
           batch_size = NULL,
           conv_crit = -Inf,
@@ -188,7 +187,7 @@ lantern_logistic_reg.matrix <- function(x,
                                penalty = 0,
                                validation = 0.1,
                                optimizer = "LBFGS",
-                               learn_rate = 0.01,
+                               learn_rate = 1,
                                momentum = 0.0,
                                batch_size = NULL,
                                conv_crit = -Inf,
@@ -222,7 +221,7 @@ lantern_logistic_reg.formula <-
           penalty = 0,
           validation = 0.1,
           optimizer = "LBFGS",
-          learn_rate = 0.01,
+          learn_rate = 1,
           momentum = 0.0,
           batch_size = NULL,
           conv_crit = -Inf,
@@ -256,7 +255,7 @@ lantern_logistic_reg.recipe <-
           penalty = 0,
           validation = 0.1,
           optimizer = "LBFGS",
-          learn_rate = 0.01,
+          learn_rate = 1,
           momentum = 0.0,
           batch_size = NULL,
           conv_crit = -Inf,
@@ -389,7 +388,7 @@ lantern_logistic_reg_reg_fit_imp <-
           penalty = 0,
           validation = 0.1,
           optimizer = "LBFGS",
-          learn_rate = 0.01,
+          learn_rate = 1,
           momentum = 0.0,
           conv_crit = -Inf,
           verbose = FALSE,

--- a/man/lantern_linear_reg.Rd
+++ b/man/lantern_linear_reg.Rd
@@ -20,7 +20,7 @@ lantern_linear_reg(x, ...)
   penalty = 0.001,
   validation = 0,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -35,7 +35,7 @@ lantern_linear_reg(x, ...)
   penalty = 0.001,
   validation = 0,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -50,7 +50,7 @@ lantern_linear_reg(x, ...)
   penalty = 0.001,
   validation = 0,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -65,7 +65,7 @@ lantern_linear_reg(x, ...)
   penalty = 0.001,
   validation = 0,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -104,10 +104,10 @@ validation set.}
 \item{optimizer}{The method used in the optimization procedure. Possible choices
 are 'LBFGS' and 'SGD'. Default is 'LBFGS'.}
 
-\item{learn_rate}{A positive number (usually less than 0.1).}
+\item{learn_rate}{A positive number. Default is 1 for LBFGS; smaller valuesare normally chosen for other optimizers.}
 
 \item{momentum}{A positive number on \verb{[0, 1]} for the momentum parameter in
-gradient decent.}
+gradient descent.}
 
 \item{batch_size}{An integer for the number of training set points in each
 batch.}
@@ -172,7 +172,7 @@ if (torch::torch_is_installed()) {
  set.seed(1)
  lantern_linear_reg(x = as.matrix(ames_train[, c("Longitude", "Latitude")]),
                     y = ames_train$Sale_Price,
-                    penalty = 0.10, epochs = 20, batch_size = 32)
+                    penalty = 0.10, epochs = 1, batch_size = 64)
 
  # Using recipe
  library(recipes)
@@ -194,7 +194,7 @@ if (torch::torch_is_installed()) {
 
  set.seed(2)
  fit <- lantern_linear_reg(ames_rec, data = ames_train,
-                           epochs = 20, batch_size = 32)
+                           epochs = 5, batch_size = 32)
  fit
 
  autoplot(fit)

--- a/man/lantern_linear_reg.Rd
+++ b/man/lantern_linear_reg.Rd
@@ -104,7 +104,8 @@ validation set.}
 \item{optimizer}{The method used in the optimization procedure. Possible choices
 are 'LBFGS' and 'SGD'. Default is 'LBFGS'.}
 
-\item{learn_rate}{A positive number. Default is 1 for LBFGS; smaller valuesare normally chosen for other optimizers.}
+\item{learn_rate}{A positive number. Default is 1 for LBFGS; smaller values
+are normally chosen for other optimizers.}
 
 \item{momentum}{A positive number on \verb{[0, 1]} for the momentum parameter in
 gradient descent.}

--- a/man/lantern_logistic_reg.Rd
+++ b/man/lantern_logistic_reg.Rd
@@ -20,7 +20,7 @@ lantern_logistic_reg(x, ...)
   penalty = 0,
   validation = 0.1,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -35,7 +35,7 @@ lantern_logistic_reg(x, ...)
   penalty = 0,
   validation = 0.1,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -50,7 +50,7 @@ lantern_logistic_reg(x, ...)
   penalty = 0,
   validation = 0.1,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -65,7 +65,7 @@ lantern_logistic_reg(x, ...)
   penalty = 0,
   validation = 0.1,
   optimizer = "LBFGS",
-  learn_rate = 0.01,
+  learn_rate = 1,
   momentum = 0,
   batch_size = NULL,
   conv_crit = -Inf,
@@ -104,7 +104,7 @@ validation set.}
 \item{optimizer}{The method used in the optimization procedure. Possible choices
 are 'LBFGS' and 'SGD'. Default is 'LBFGS'.}
 
-\item{learn_rate}{A positive number (usually less than 0.1).}
+\item{learn_rate}{A positive number. Default is 1 for LBFGS; smaller valuesare normally chosen for other optimizers.}
 
 \item{momentum}{A positive number on \verb{[0, 1]} for the momentum parameter in
 gradient decent.}
@@ -171,7 +171,7 @@ if (torch::torch_is_installed()) {
  set.seed(1)
  lantern_logistic_reg(x = as.matrix(cells_train[, c("fiber_width_ch_1", "width_ch_1")]),
                       y = cells_train$class,
-                      penalty = 0.10, epochs = 20L)
+                      penalty = 0.10, epochs = 3)
 
  # Using recipe
  library(recipes)
@@ -185,7 +185,7 @@ if (torch::torch_is_installed()) {
 
  set.seed(2)
  fit <- lantern_logistic_reg(cells_rec, data = cells_train,
-                             penalty = .01, epochs = 20L)
+                             penalty = .01, epochs = 5)
  fit
 
  autoplot(fit)
@@ -212,7 +212,7 @@ if (torch::torch_is_installed()) {
   step_normalize(all_predictors())
 
  set.seed(3)
- fit <- lantern_logistic_reg(rec, data = penguins_train, epochs = 20L)
+ fit <- lantern_logistic_reg(rec, data = penguins_train, epochs = 5)
  fit
 
  predict(fit, penguins_test) \%>\%

--- a/man/lantern_logistic_reg.Rd
+++ b/man/lantern_logistic_reg.Rd
@@ -104,7 +104,8 @@ validation set.}
 \item{optimizer}{The method used in the optimization procedure. Possible choices
 are 'LBFGS' and 'SGD'. Default is 'LBFGS'.}
 
-\item{learn_rate}{A positive number. Default is 1 for LBFGS; smaller valuesare normally chosen for other optimizers.}
+\item{learn_rate}{A positive number. Default is 1 for LBFGS; smaller values
+are normally chosen for other optimizers.}
 
 \item{momentum}{A positive number on \verb{[0, 1]} for the momentum parameter in
 gradient decent.}

--- a/tests/testthat/test-lantern_linear_reg-fit.R
+++ b/tests/testthat/test-lantern_linear_reg-fit.R
@@ -7,7 +7,7 @@ test_that("linear regression test", {
   )
 
   expect_error(
-    fit <- lantern_linear_reg(y ~ ., df, epochs = 10, learn_rate = 0.1),
+    fit <- lantern_linear_reg(y ~ ., df, epochs = 2),
     regexp = NA
   )
 

--- a/tests/testthat/test-lantern_logistic_reg-fit.R
+++ b/tests/testthat/test-lantern_logistic_reg-fit.R
@@ -9,7 +9,7 @@ test_that("logistic regression", {
  df$logit <- NULL
 
  expect_error(
-  fit <- lantern_logistic_reg(y ~ ., df, epochs = 10, learn_rate = 0.1, verbose = TRUE),
+  fit <- lantern_logistic_reg(y ~ ., df, epochs = 2, verbose = TRUE),
   regexp = NA
  )
 


### PR DESCRIPTION
Hi,

I've set the default `learn_rate` for lbfgs to 1 (its `torch` default) everywhere. 

I've also modified the examples and tests to run for 1-5 epochs only. (Actually, nearly in every example/test I found that nothing changed anymore after epoch 2 ... I only used 5 in examples that display a learning curve, so it does not look too weird :-))

Haven't checked memory usage yet, but we'll see when CI runs ... :-)